### PR TITLE
Drop QuantifiedCode integration.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,6 @@
     :target: https://travis-ci.org/amateja/django-bitoptions
 .. image:: https://img.shields.io/coveralls/amateja/django-bitoptions.svg
     :target: https://coveralls.io/github/amateja/django-bitoptions
-.. image:: https://www.quantifiedcode.com/api/v1/project/9d2810191a234414a3edf7843f5d1c1c/badge.svg
-    :target: https://www.quantifiedcode.com/app/project/9d2810191a234414a3edf7843f5d1c1c
 .. image:: https://img.shields.io/pypi/v/django-bitoptions.svg
     :target: https://pypi.python.org/pypi/django-bitoptions
 .. image:: https://img.shields.io/pypi/format/django-bitoptions.svg


### PR DESCRIPTION
Unfortunately QuantifiedCode no longer provides online service for checking code quality. Therefore all integration should be removed. In short term it could be partially replaced with flake8.