### PR TITLE
Django 2.0 support.

### DIFF
--- a/bitoptions/widgets.py
+++ b/bitoptions/widgets.py
@@ -16,7 +16,7 @@ class BitOptionsWidget(forms.CheckboxSelectMultiple):
         return sum(map(int, super(BitOptionsWidget, self).value_from_datadict(
             data, files, name)))
 
-    def render(self, name, value, attrs=None, choices=()):
+    def render(self, name, value, attrs=None, renderer=None):
         """
         Returns HTML for the widget, as a Unicode string.
         """
@@ -24,4 +24,8 @@ class BitOptionsWidget(forms.CheckboxSelectMultiple):
             value = number2powers(value.value)
         elif isinstance(value, int):
             value = number2powers(value)
-        return super(BitOptionsWidget, self).render(name, value, attrs, choices)
+        try:
+            return super(BitOptionsWidget, self).render(name, value,
+                                                        attrs, renderer)
+        except TypeError:
+            return super(BitOptionsWidget, self).render(name, value, attrs)

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -123,11 +123,10 @@ class BitOptionFieldTests(TestCase):
         """
         Tests BitOptionsWidget.render method with integer value.
         """
-        widget = BitOptionsWidget()
-        html = widget.render('toppings', 131140, {'id': 'id_toppings'},
-                             TOPPINGS)
+        widget = BitOptionsWidget(choices=TOPPINGS)
+        html = widget.render('toppings', 131140, {'id': 'id_toppings'})
         self.assertEqual(html.count('<li>'), len(TOPPINGS))
-        self.assertEqual(html.count('checked="checked"'),
+        self.assertEqual(html.count(' checked'),
                          len(TOPPINGS.get_selected_values(131140)))
 
     def test_widget_render_bitoptions(self):
@@ -135,11 +134,10 @@ class BitOptionFieldTests(TestCase):
         Tests BitOptionsWidget.render method with BitOptions object.
         """
         TOPPINGS.value = 131140
-        widget = BitOptionsWidget()
-        html = widget.render('toppings', TOPPINGS, {'id': 'id_toppings'},
-                             TOPPINGS)
+        widget = BitOptionsWidget(choices=TOPPINGS)
+        html = widget.render('toppings', TOPPINGS, {'id': 'id_toppings'})
         self.assertEqual(html.count('<li>'), len(TOPPINGS))
-        self.assertEqual(html.count('checked="checked"'),
+        self.assertEqual(html.count(' checked'),
                          len(TOPPINGS.get_selected_values(131140)))
 
     def test_widget_value_from_datadict(self):

--- a/testproject/testproject/settings.py
+++ b/testproject/testproject/settings.py
@@ -19,16 +19,15 @@ INSTALLED_APPS = (
     'testapp'
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = MIDDLEWARE_CLASSES = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
-)
+]
 
 ROOT_URLCONF = 'testproject.urls'
 

--- a/testproject/testproject/urls.py
+++ b/testproject/testproject/urls.py
@@ -1,6 +1,6 @@
-from django.conf.urls import include, url
+from django.conf.urls import url
 from django.contrib import admin
 
 urlpatterns = [
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
 ]


### PR DESCRIPTION
A few things changes in terms of Django 2.0 support for this project:
* In Django 1.10 `choices` keyword was removed form `django.forms.CheckboxSelectMultiple.render` method (see: https://docs.djangoproject.com/en/1.10/releases/1.10/#miscellaneous).
* Starting from Django 1.11 widgets are rendered with templates (see: https://docs.djangoproject.com/en/1.11/releases/1.11/#template-based-widget-rendering).

Well... it's not strictly related with django-bitoptions but with application it uses for testing so it's stil valuable to mention that in Django 2.0:
* There is no longer SessionAuthenticationMiddleware available (see https://docs.djangoproject.com/en/2.0/releases/2.0/#miscellaneous).
* Support for passing a 3-tuple (including admin.site.urls) as the first argument to include() is removed. (see: https://docs.djangoproject.com/en/2.0/releases/2.0/#features-removed-in-2-0).