### PR TITLE
code unification

### DIFF
--- a/bitoptions/fields.py
+++ b/bitoptions/fields.py
@@ -88,22 +88,5 @@ class BitOptionsField(SimpleBitOptionsField):
         value = super(BitOptionsField, self).to_python(value)
         return BitOptions(self.options.flags, value)
 
-    def get_prep_value(self, value):
-        """
-        Takes current value of the model's attribute, and the method returns
-        data in a format that has been prepared for use as a parameter in
-        a query.
-        """
-        if isinstance(value, BitOptions):
-            return super(BitOptionsField, self).get_prep_value(value.value)
-        return super(BitOptionsField, self).get_prep_value(value)
-
-    def get_prep_lookup(self, lookup_type, value):
-        """
-        Prepares value to the database prior to be used in a lookup.
-        """
-        value = self.get_prep_value(value)
-        return super(BitOptionsField, self).get_prep_lookup(lookup_type, value)
-
 
 SimpleBitOptionsField.register_lookup(BitwiseAnd)

--- a/bitoptions/utils.py
+++ b/bitoptions/utils.py
@@ -36,6 +36,9 @@ class BitOptions(object):
     def __len__(self):
         return len(self._options)
 
+    def __int__(self):
+        return self.value
+
     def get_selected_values(self, selection=None):
         """
         Returns a list of options for the given selection.


### PR DESCRIPTION
In Django 1.10 `django.db.models.fields.Field.get_prep_lookup` method was removed (see https://docs.djangoproject.com/en/dev/releases/1.10/#field-get-prep-lookup-and-field-get-db-prep-lookup-methods-are-removed). Anyway reason of `bitoptions.fields.BitOptionsField.get_prep_lookup` method was to retrieve `value` property of `bitoptions.utils.BitOptions` objects using `bitoptions.fields.BitOptionsField.get_prep_value` method.

Eventually both `django.db.models.lookups.Lookup.get_prep_lookup` and `django.db.models.fields.IntegerField.get_prep_lookup` end up with calling `django.db.models.fields.IntegerField.get_prep_value` which all in all comes down to casting a value to `int`. 

So how about removing both of them and allow `bitoptions.utils.BitOptions` objects to be castable to int?

Are there any breaking changes? I believe there are none. Using with Django 1.8 and 1.9 calling either of removed methods trigger parent class method. In Django 1.10 and newer there is no `django.db.models.fields.Field.get_prep_lookup` so removing it does not break anything.